### PR TITLE
Fix FormattedMessage so it works with children

### DIFF
--- a/src/FormattedMessage.js
+++ b/src/FormattedMessage.js
@@ -1,10 +1,18 @@
-import React, { PropTypes } from 'react';
+import React, { PropTypes, isValidElement, createElement } from 'react';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 
 const FormattedMessage = props => (
   <Intl.FormattedMessage {...props}>
-    {localized => <Text style={props.style}>{localized}</Text>}
+    {(...nodes) => {
+      const newNodes = nodes.map((node) => {
+        if (!isValidElement(node)) {
+          return (<Text style={props.style}>{node}</Text>);
+        }
+        return node;
+      });
+      return createElement(Text, null, ...newNodes);
+    }}
   </Intl.FormattedMessage>
 );
 


### PR DESCRIPTION
Fix FormattedMessage so it works with children so we can do something like this:

``` javascript
<FormattedMessage
            id="greeting.welcome_message"
            defaultMessage={`
                Welcome {name}, you have received {unreadCount, plural,
                    =0 {no new messages}
                    one {{formattedUnreadCount} new message}
                    other {{formattedUnreadCount} new messages}
                } since {formattedLastLoginTime}.
            `}
            values={{
                name: {name},
                unreadCount: unreadCount,
                formattedUnreadCount: (
                    <FormattedNumber value={unreadCount} />
                ),
                formattedLastLoginTime: (
                    <FormattedRelative
                        value={lastLoginTime}
                        updateInterval={1000}
                    />
                ),
            }}
        />
```

like this example: https://github.com/yahoo/react-intl/blob/master/examples/nested/src/client/components/widgets/greeting.js
