### PR TITLE
Adding new prop-types library

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "homepage": "https://github.com/frostney/react-intl-native#readme",
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-intl": "^2.1.2"
   },
   "devDependencies": {
@@ -77,9 +78,9 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.12.0",
     "nyc": "^6.4.0",
-    "react": "^0.14.8",
+    "react": "^0.14.9",
     "react-addons-test-utils": "^0.14.8",
-    "react-dom": "^0.14.8",
+    "react-dom": "^0.14.9",
     "react-native": "^0.25.1",
     "rimraf": "^2.5.2",
     "rollup-babel-lib-bundler": "^2.5.5"

--- a/src/FormattedDate.js
+++ b/src/FormattedDate.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 

--- a/src/FormattedHTMLMessage.js
+++ b/src/FormattedHTMLMessage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 

--- a/src/FormattedMessage.js
+++ b/src/FormattedMessage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, isValidElement, createElement } from 'react';
+import React, { isValidElement, createElement } from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 

--- a/src/FormattedNumber.js
+++ b/src/FormattedNumber.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 

--- a/src/FormattedPlural.js
+++ b/src/FormattedPlural.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 

--- a/src/FormattedRelative.js
+++ b/src/FormattedRelative.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 

--- a/src/FormattedTime.js
+++ b/src/FormattedTime.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import Intl from 'react-intl';
 


### PR DESCRIPTION
React has deprecated PropTypes from the base library and created a separate package, `prop-types`. As of v 15.5 of React, PropTypes has been completely removed. (See [here](https://reactjs.org/docs/typechecking-with-proptypes.html))

Also bumping the minimum versions of `react` and `react-dom` per the [documentation](https://www.npmjs.com/package/prop-types#compatibility)